### PR TITLE
refacto: display add/filter buttons directly on the webapp

### DIFF
--- a/src/html/issues.html
+++ b/src/html/issues.html
@@ -13,21 +13,12 @@
   ${require('./spinner.html')}
 </div>
 <div class="fixed-action-btn">
-  <a class="btn-floating btn-large yellow darken-3 black-text">
-    <i class="large material-icons">more_vert</i>
+  <a class="btn-floating btn-large blue darken-3 black-text modal-trigger" href="#modal-filters">
+    <i class="material-icons">filter_list</i>
   </a>
-  <ul>
-    <li>
-      <a class="btn-floating blue darken-1 black-text modal-trigger" href="#modal-filters">
-        <i class="material-icons">filter_list</i>
-      </a>
-    </li>
-    <li>
-      <a class="btn-floating green darken-3 black-text" onclick="startForm()">
-        <i class="material-icons">add</i>
-      </a>
-    </li>
-  </ul>
+  <a class="btn-floating btn-large yellow darken-3 black-text" onclick="startForm()">
+    <i class="material-icons">add</i>
+  </a>
 
   <!-- Modal for filters -->
   ${require('./filters.html')}


### PR DESCRIPTION
## Goal
Let users know they can fitler observations and add one as the yellow button can be forgotten, especially on desktop
 
## Before
![Screenshot from 2019-09-21 18-22-09](https://user-images.githubusercontent.com/4059615/65376174-1ada4880-dc9d-11e9-815f-83461695331c.png)
## After
![Screenshot from 2019-09-21 18-21-51](https://user-images.githubusercontent.com/4059615/65376176-1e6dcf80-dc9d-11e9-9c49-441a16548049.png)
