### PR TITLE
Fixes behaviour of issues list and map when no issue to display

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1,12 +1,12 @@
 html,
 body {
-	padding: 0;
-	margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 body {
-	width: 100%;
-	height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 @import "~materialize-css/sass/materialize.scss";
@@ -18,157 +18,167 @@ body {
 @import "~leaflet.locatecontrol/src/L.Control.Locate.scss";
 
 .leaflet-touch .leaflet-control-layers-toggle {
-	height: 30px;
-	width: 30px;
+  height: 30px;
+  width: 30px;
 }
 
 .leaflet-top,
 .leaflet-bottom,
 .leaflet-left,
 .leaflet-right {
-	z-index: 997;
+  z-index: 997;
 }
 
 @import "spinner.scss";
 @import "image-drawable.scss";
 
 .sidenav {
-	ul.tabs {
-		height: 100%;
-	}
-	#version {
-		position: absolute;
-		bottom: (56px + 48px);
-		width: 100%;
-	}
-	#version-server {
-		position: absolute;
-		bottom: 56px;
-		width: 100%;
-	}
+  ul.tabs {
+    height: 100%;
+  }
+  #version {
+    position: absolute;
+    bottom: (56px + 48px);
+    width: 100%;
+  }
+  #version-server {
+    position: absolute;
+    bottom: 56px;
+    width: 100%;
+  }
 }
 
 nav.nav-extended {
-	.nav-wrapper {
-		overflow-y: hidden;
-	}
+  .nav-wrapper {
+    overflow-y: hidden;
+  }
 }
 
 #content {
-	ul.tabs {
-		position: fixed;
-		top: 64px;
-		z-index: 997;
-	}
-	@media #{$small-and-down} {
-		ul.tabs {
-			top: 56px;
-		}
-	}
-	& > div {
-		margin-top: 48px;
-	}
+  ul.tabs {
+    position: fixed;
+    top: 64px;
+    z-index: 997;
+  }
+  @media #{$small-and-down} {
+    ul.tabs {
+      top: 56px;
+    }
+  }
+  & > div {
+    margin-top: 48px;
+  }
 }
 
 #issues {
-	.spinner {
-		display: none;
-		&:only-child {
-			display: unset;
-		}
-	}
+  .spinner {
+    display: none;
+    &:only-child {
+      display: unset;
+    }
+  }
 
-	#issues-map {
-		height: calc(100vh - 113px);
-		.spinner {
-			display: block;
-		}
-	}
+  #issues-map {
+    height: calc(100vh - 113px);
+    .spinner {
+      display: block;
+    }
+  }
 }
 
 #stats {
-	canvas {
-		min-height: 350px;
-	}
+  canvas {
+    min-height: 350px;
+  }
 }
 
 .cards-container {
-	display: flex;
-	flex-wrap: wrap;
-	.card {
-		cursor: pointer;
-		height: calc(100% - 1rem);
-		.card-image {
-			display: flex;
-			align-items: center;
-		}
-	}
+  display: flex;
+  flex-wrap: wrap;
+  .card {
+    cursor: pointer;
+    height: calc(100% - 1rem);
+    .card-image {
+      display: flex;
+      align-items: center;
+    }
+  }
 }
 
 #modal-form {
-	.card-panel {
-		height: calc(100% - 1rem);
-		margin-left: unset;
-		margin-right: unset;
-	}
-	#form-map {
-		min-height: 200px;
-	}
-	canvas {
-		max-height: 200px;
-		max-width: 100%;
-	}
+  .card-panel {
+    height: calc(100% - 1rem);
+    margin-left: unset;
+    margin-right: unset;
+  }
+  #form-map {
+    min-height: 200px;
+  }
+  canvas {
+    max-height: 200px;
+    max-width: 100%;
+  }
 
-	#related-issues {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		.related-issue {
-			margin-bottom: 10px;
-			max-height: 180px;
-			position: relative;
-			img.materialboxed {
-				max-height: 180px;
-				filter: opacity(30%) grayscale(90%);
-				&.active {
-					filter: unset;
-				}
-			}
-			a.btn-floating {
-				position: absolute;
-				right: 5px;
-				bottom: 5px;
-			}
-			&.checked {
-				img.materialboxed {
-					filter: unset;
-				}
-				a.btn-floating {
-					background-color: #F44336 !important;
-				}
-			}
-		}
-		&.invalid {
-			border: solid 2px red;
-		}
-	}
+  #related-issues {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    .related-issue {
+      margin-bottom: 10px;
+      max-height: 180px;
+      position: relative;
+      img.materialboxed {
+        max-height: 180px;
+        filter: opacity(30%) grayscale(90%);
+        &.active {
+          filter: unset;
+        }
+      }
+      a.btn-floating {
+        position: absolute;
+        right: 5px;
+        bottom: 5px;
+      }
+      &.checked {
+        img.materialboxed {
+          filter: unset;
+        }
+        a.btn-floating {
+          background-color: #f44336 !important;
+        }
+      }
+    }
+    &.invalid {
+      border: solid 2px red;
+    }
+  }
 }
 
 #modal-filters {
-	h6 {
-		cursor: pointer;
-	}
+  h6 {
+    cursor: pointer;
+  }
 }
 
 .row {
-	.col {
-		margin-right: auto;
-	}
+  .col {
+    margin-right: auto;
+  }
 }
 
 .file-field {
-	display: flex;
-	align-items: center;
-	margin-top: 0px;
-	margin-bottom: 0px;
+  display: flex;
+  align-items: center;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.no-issue-to-display-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+.no-issue-to-display {
+  font-size: 1.4rem;
+  margin-top: 8rem;
 }

--- a/src/js/issue-filter.js
+++ b/src/js/issue-filter.js
@@ -22,7 +22,7 @@ export async function init() {
 		// Fill city select + count
 		var scope = await vigilo.getScope();
 		var cities = scope.cities.sort((a, b) => parseInt(a.population) <= parseInt(b.population))
-		if (cities && cities.length > 0 && issues[0].cityname !== undefined) {
+		if (cities && cities.length > 0 && issues.length && issues[0].cityname !== undefined) {
 			for (var i in cities) {
 				$("#modal-filters #city-select")
 					.append(`<div class="col s12 m6 l4">
@@ -50,7 +50,7 @@ export async function init() {
 		addBadge("dow", countIssueDay(issues));
 
 		// My issue count
-		$("input[name=owner]").parent().parent().parent().find("h6").append(' ('+countIssueFromMe(issues)+')');
+		$("input[name=owner]").parent().parent().parent().find("h6").append(' (' + countIssueFromMe(issues) + ')');
 
 		M.Modal.init($("#modal-filters"));
 		M.Modal.getInstance($("#modal-filters")).options.onCloseStart = function () {
@@ -136,7 +136,7 @@ function countIssueStatus(issues) {
 	}, count);
 	return count;
 }
-function countIssueAge(issues){
+function countIssueAge(issues) {
 	var count = {
 		1: 0,
 		3: 0,
@@ -146,8 +146,8 @@ function countIssueAge(issues){
 	var date_now = Date.now();
 	issues.reduce(function (accumulator, currentIssue) {
 		var issue_age = (date_now - currentIssue.date_obj) / (1000 * 60 * 60 * 24);
-		for (var i in accumulator){
-			if (i > issue_age){
+		for (var i in accumulator) {
+			if (i > issue_age) {
 				accumulator[i]++
 			}
 		}
@@ -155,19 +155,19 @@ function countIssueAge(issues){
 	}, count);
 	return count;
 }
-function countIssueHour(issues){
+function countIssueHour(issues) {
 	var count = {
 		"morning": 0,
 		"afternoon": 0,
 		"night": 0,
 	}
-	var morning = [6,7,8,9,10,11,12];
-	var afternoon = [13,14,15,16,17,18,19];
+	var morning = [6, 7, 8, 9, 10, 11, 12];
+	var afternoon = [13, 14, 15, 16, 17, 18, 19];
 	issues.reduce(function (accumulator, currentIssue) {
 		var hour = currentIssue.date_obj.getHours();
-		if (morning.indexOf(hour) != -1){
+		if (morning.indexOf(hour) != -1) {
 			accumulator.morning++
-		} else if (afternoon.indexOf(hour) != -1){
+		} else if (afternoon.indexOf(hour) != -1) {
 			accumulator.afternoon++
 		} else {
 			accumulator.night++
@@ -177,16 +177,16 @@ function countIssueHour(issues){
 	}, count);
 	return count;
 }
-function countIssueDay(issues){
+function countIssueDay(issues) {
 	var count = {
 		"worked": 0,
 		"weekend": 0,
 	}
-	var worked = [1,2,3,4,5];
+	var worked = [1, 2, 3, 4, 5];
 
 	issues.reduce(function (accumulator, currentIssue) {
 		var day = currentIssue.date_obj.getDay();
-		if (worked.indexOf(day) != -1){
+		if (worked.indexOf(day) != -1) {
 			accumulator.worked++
 		} else {
 			accumulator.weekend++
@@ -197,8 +197,8 @@ function countIssueDay(issues){
 	return count;
 }
 
-function countIssueFromMe(issues){
-	return issues.filter((item)=>{
+function countIssueFromMe(issues) {
+	return issues.filter((item) => {
 		return LocalDataManager.getTokenSecretId(item.token) != undefined
 	}).length
 }

--- a/src/js/issue-list.js
+++ b/src/js/issue-list.js
@@ -14,11 +14,16 @@ export async function cleanIssues() {
 export async function displayIssues(count) {
 	try {
 		var issues = await dataManager.getData();
-		issues = issues.slice(offset, offset + count);
-		offset += issues.length;
-		issues.forEach((issue) => {
-			$("#issues .cards-container").append(issueCard(issue))
-		})
+		if (issues.length) {
+			issues = issues.slice(offset, offset + count);
+			offset += issues.length;
+			issues.forEach((issue) => {
+				$("#issues .cards-container").append(issueCard(issue))
+			})
+		} else {
+			$("#issues .cards-container").append('<div class="no-issue-to-display-container"><div class="no-issue-to-display">Aucun signalement..</div></div>')
+		}
+
 	} catch (e) {
 		$("#issues").empty().append(errorCard(e));
 	}
@@ -29,7 +34,7 @@ export async function viewIssue(token) {
 	var modal = M.Modal.getInstance($("#modal-issue")[0]);
 	var issues = await dataManager.getData();
 	var issue = issues.filter(item => item.token == token);
-	if( issue.length > 0) {
+	if (issue.length > 0) {
 		$("#modal-issue").empty().append(await issueDetail(issue[0]));
 		M.Materialbox.init($("#modal-issue .materialboxed"));
 		window.history.replaceState({}, '', issue[0].permLink)

--- a/src/js/issue-map.js
+++ b/src/js/issue-map.js
@@ -11,6 +11,12 @@ import dataManager from './dataManager';
 
 var issuesmap, issueslayer;
 
+function fitMapBoundsFromIssues() {
+	if (Object.keys(issueslayer.getBounds()).length) {
+		issuesmap.fitBounds(issueslayer.getBounds())
+	}
+}
+
 export async function init() {
 	if (issuesmap !== undefined) {
 		issuesmap.invalidateSize()
@@ -55,9 +61,9 @@ export async function init() {
 var firstFocus = true;
 export async function focus() {
 	issuesmap.invalidateSize();
-	if (firstFocus){
+	if (firstFocus) {
 		firstFocus = false;
-		issuesmap.fitBounds(issueslayer.getBounds())
+		fitMapBoundsFromIssues()
 	}
 }
 export async function cleanIssues() {
@@ -85,19 +91,19 @@ export async function displayIssues(nozoom) {
 		);
 		issueslayer.addLayer(marker);
 	}
-	if (nozoom != true){
-		issuesmap.fitBounds(issueslayer.getBounds())
+	if (nozoom != true) {
+		fitMapBoundsFromIssues()
 	}
 
 }
 
 
-export async function centerOnIssue (token) {
+export async function centerOnIssue(token) {
 	focus();
 	var issues = await dataManager.getData();
 	var issue = issues.filter(item => item.token == token)[0];
-  issuesmap.setView([issue.lat_float, issue.lon_float], 18)
-  L.timedOutMarker([issue.lat_float, issue.lon_float]).addTo(issuesmap);
+	issuesmap.setView([issue.lat_float, issue.lon_float], 18)
+	L.timedOutMarker([issue.lat_float, issue.lon_float]).addTo(issuesmap);
 	M.Tabs.getInstance($("#issues .tabs")[0]).select('issues-map')
 	M.Modal.getInstance($("#modal-issue")[0]).close();
 }


### PR DESCRIPTION
### BUG
Un soucis avec l'instance Nantaise actuellement et le service /get_issues qui ne retourne pas de données remonte le problème que quand pas de donnée, alors l'utilisateur prend un message technique incompréhensible.

https://github.com/jesuisundesdeux/vigilo-webapp/issues/77

### Reproduction du pbm
Vider entièrement la table contenant les issues 

### Navigateur
Tous 

###  Proposition de résolution 
Traitement différent en cas de liste d'issues vide et adaptation des comportements de la map.

![image](https://user-images.githubusercontent.com/1191763/112041299-888f5b00-8b46-11eb-937e-68c9c4307004.png)


Voir le commit de la PR.
Je suis désolé mon IDE a formaté les fichiers que j'ai impacté (y a moyen de review en ignorant les whitespaces https://github.com/jesuisundesdeux/vigilo-webapp/pull/78/files?diff=unified&w=1)

### Zone géographique
Toutes

### Version 
Toutes

