### PR TITLE
nominatim does not return complete address with bad zoom

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -332,7 +332,7 @@ async function setFormMapPoint(latlng, address) {
     M.updateTextFields();
   } else {
     //Reversegeocoding
-    formmap.geocoderCtrl.options.geocoder.reverse(mapmarker.getLatLng(), 1, function (result) {
+    formmap.geocoderCtrl.options.geocoder.reverse(mapmarker.getLatLng(), formmap.options.crs.scale(formmap.getZoom()), function (result) {
       if (result.length > 0) {
         $("#issue-address").val(addressFormat(result[0]))
         M.updateTextFields();


### PR DESCRIPTION
Autour du 2 août et du 11 août, un bug empêche le remplissage automatique des adresses au clic sur la carte, on obtient un `, undefined`. Reproduit au moins sous Firefox. 

![image](https://github.com/jesuisundesdeux/vigilo-webapp/assets/1990148/c776bf2d-04b3-4ce7-9be7-214a1cb71716)

Un appel est fait à l'url suivante : https://nominatim.openstreetmap.org/reverse?lat=47.20644710863929&lon=-1.5275367200592886&zoom=-8&addressdetails=1&format=json
Au moment de mon test, les infos de l'adresse n'y sont effectivement pas. Le zoom `-8` n'est pas valide (on s'attend à avoir quelque chose entre 0 et 20). S'il est corrigé (https://nominatim.openstreetmap.org/reverse?lat=47.20644710863929&lon=-1.5275367200592886&zoom=18&addressdetails=1&format=json) l'adresse complète est renvoyée.

Une valeur de `1` en dur est fournie à la fonction permettant de passer des coordonnées à l'adresse, le code du reverse la transforme effectivement en `-8` (résultat de `Math.round(Math.log(1 / 256) / Math.log(2))`).
Je propose de modifier avec le code trouvé ici : https://github.com/perliedman/leaflet-control-geocoder/blob/master/demo/index.html#L63 (je n'ai pas trouvé de doc formelle)

Je ne comprends pas pourquoi habituellement ça fonctionne et que là ça échoue à 2 semaines d'écart.